### PR TITLE
Fix window controls are broken when dark / light theme selected

### DIFF
--- a/chrome/config.css
+++ b/chrome/config.css
@@ -37,6 +37,8 @@
 
     /******WINDOW CONTROL PLACEMENT VARS******/
     --wc-vertical-shift: 18px;
+    /* For Ubuntu */
+    /* --wc-vertical-shift: 12px; */
     /* larger value moves window controls down,*/
     /* can be negative(moves controls up) */
     /* Experiemntal: 55px if tabline visible, -25px if tabline hidden */

--- a/chrome/window-controls/window-controls.css
+++ b/chrome/window-controls/window-controls.css
@@ -6,6 +6,14 @@
     min-width: 14px !important;
 }
 
+/* For Ubuntu */
+/* .titlebar-button > .toolbarbutton-icon {
+    height: 24px !important;
+    min-height: 24px !important;
+    width: 24px !important;
+    min-width: 24px !important;
+} */
+
 #titlebar {
     -moz-appearance: none !important;
 }
@@ -15,6 +23,13 @@
     background: none !important;
     -moz-context-properties: fill, fill-opacity !important;
 }
+
+/* For Ubuntu */
+/* .titlebar-button {
+    padding: 0px 2px !important;
+    background: none !important;
+    -moz-context-properties: fill, fill-opacity !important;
+} */
 
 .titlebar-buttonbox {
     display: flex;
@@ -29,6 +44,14 @@
     list-style-image: url(circle.svg) !important;
 }
 
+/* For Ubuntu */
+/* .titlebar-close {
+    -moz-appearance: none !important;
+    fill: var(--red) !important;
+    opacity: 0.7 !important;
+    list-style-image: url(circle-close-p.svg) !important;
+} */
+
 .titlebar-close:hover {
     opacity: 1 !important;
 }
@@ -40,6 +63,14 @@
     opacity: 0.7 !important;
     list-style-image: url(circle.svg) !important;
 }
+
+/* For Ubuntu */
+/* .titlebar-min {
+    -moz-appearance: none !important;
+    fill: var(--yellow) !important;
+    opacity: 0.7 !important;
+    list-style-image: url(circle-min-p.svg) !important;
+} */
 
 .titlebar-min:hover {
     opacity: 1 !important;
@@ -53,6 +84,14 @@
     list-style-image: url(circle.svg) !important;
 }
 
+/* For Ubuntu */
+/* .titlebar-max {
+    -moz-appearance: none !important;
+    fill: var(--green) !important;
+    opacity: 0.7 !important;
+    list-style-image: url(circle-max-p.svg) !important;
+} */
+
 .titlebar-max:hover {
     opacity: 1 !important;
 }
@@ -64,6 +103,14 @@
     opacity: 0.7 !important;
     list-style-image: url(circle.svg) !important;
 }
+
+/* For Ubuntu */
+/* .titlebar-restore {
+    -moz-appearance: none !important;
+    fill: var(--green) !important;
+    opacity: 0.7 !important;
+    list-style-image: url(circle-max-p.svg) !important;
+} */
 
 .titlebar-restore:hover {
     opacity: 1 !important;


### PR DESCRIPTION
Fix window controls are broken when dark / light theme selected.

OS: Ubuntu 22.04

<u>Broken</u>

![Broken](https://github.com/ekishouTV/FlyingFox/assets/45916397/ecad2c66-9a6a-4010-b4b0-0ec0b9348b67)

<u>Fixed</u>

![Fixed](https://github.com/ekishouTV/FlyingFox/assets/45916397/60cd8e51-750f-4537-bac8-5ea8d9033c1b)
