### PR TITLE
Fix window controls are too big on Ubuntu

### DIFF
--- a/chrome/window-controls/window-controls.css
+++ b/chrome/window-controls/window-controls.css
@@ -6,14 +6,6 @@
     min-width: 14px !important;
 }
 
-/* For Ubuntu */
-/* .titlebar-button > .toolbarbutton-icon {
-    height: 24px !important;
-    min-height: 24px !important;
-    width: 24px !important;
-    min-width: 24px !important;
-} */
-
 #titlebar {
     -moz-appearance: none !important;
 }
@@ -23,13 +15,6 @@
     background: none !important;
     -moz-context-properties: fill, fill-opacity !important;
 }
-
-/* For Ubuntu */
-/* .titlebar-button {
-    padding: 0px 2px !important;
-    background: none !important;
-    -moz-context-properties: fill, fill-opacity !important;
-} */
 
 .titlebar-buttonbox {
     display: flex;


### PR DESCRIPTION
I noticed since 2024-05-29, window controls are big on Ubuntu. It is like a https://github.com/ekishouTV/FlyingFox/pull/1#issuecomment-1937986057 .

![Screenshot from 2024-06-01 18-49-17](https://github.com/ekishouTV/FlyingFox/assets/45916397/7a25a4cb-0b6a-46e9-b155-b78e33e13ce5)

This issue is fixed due to some Ubuntu specific settings.